### PR TITLE
build/ops: ceph-disk: modify owner of journal partition to ceph

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -2756,6 +2756,29 @@ class PrepareData(object):
                       self.args.data)
             self.partition = self.create_data_partition()
 
+    def set_journal_owner(self,journal = None):
+        if journal.find("/dev/disk/")!=-1:
+            out, err, ret = command([
+                'ls',
+                '-l',
+                journal,
+            ])
+            journal = "/dev/" + out.split("/")[-1]
+        num = re.findall("\d+",journal)
+        disk = journal[:journal.find(num[0])]
+        try:
+            command_check_call(
+                [
+                    'sgdisk',
+                    '--typecode=%s:%s' % (num[0],
+                                          self.partition.ptype_for_name('osd')),
+                    '--',
+                    disk,
+                ],
+            )
+        except subprocess.CalledProcessError as e:
+            raise Error(e)
+            
     def populate_data_path_device(self, *to_prepare_list):
         partition = self.partition
 
@@ -2812,6 +2835,8 @@ class PrepareData(object):
                                 '--sysname-match',
                                 os.path.basename(partition.rawdev)])
 
+        if self.args.journal != None and self.args.journal != self.args.data:
+            self.set_journal_owner(journal = self.args.journal)            
 
 class PrepareFilestoreData(PrepareData):
 


### PR DESCRIPTION
When use filestore,a single partition for journal(such as a ssd),you must change it's owner to ceph,
or you will fail to activate osd.

Signed-off-by:  Jie Teng <tengj@certusnet.com.cn>